### PR TITLE
Add phasor noise feature

### DIFF
--- a/Doc/features/phasor.md
+++ b/Doc/features/phasor.md
@@ -1,0 +1,26 @@
+# Phasor noise height map
+
+**Tag**: PHASOR
+
+**Category**: feature
+
+**Function Name**: phasor
+
+**Signature**: (vec2 pos, float amplitude, float angle, float frequency, float bandwidth, bool normalized) -> float
+
+**Spec**: Compute a height map using procedural phasor noise with a sine profile.
+
+- pos : current terrain position
+
+- amplitude : amplitude of the resulting noise
+
+- angle : angle of the main oscillation pattern
+
+- frequency : frequency of the oscillations
+
+- bandwidth : bandwidth of the noise kernels (inverse of the noise radius)
+
+- normalized : true if all oscillations should use the full range [0, amplitude]. false to allow contrast variations
+
+
+

--- a/Doc/main.md
+++ b/Doc/main.md
@@ -8,6 +8,7 @@ Features are the main functions you can use in your terrainMap fonction (inside 
 |-|-|-|
 | [fbm_gradient](features/fbm_gradient.md) | fractal gradient | FBM_GRADIENT |
 | [fbm_voronoi](features/fbm_voronoi.md) | fractal voronoi | FBM_VORONOI |
+| [phasor](features/phasor.md) | Phasor noise height map | PHASOR |
 | [plateau](features/plateau.md) | plateau | PLATEAU |
 
 

--- a/shaders/features/phasor.fs
+++ b/shaders/features/phasor.fs
@@ -1,0 +1,110 @@
+// --------------DEV-----------------
+// @TAG PHASOR
+// @FUNCTION_NAME phasor
+// @SIGNATURE (vec2 pos, float amplitude, float angle, float frequency, float bandwidth, bool normalized) -> float
+// -------------USER-----------------
+// @NAME Phasor noise height map
+// @SPEC {
+// Compute a height map using procedural phasor noise with a sine profile.
+// pos : current terrain position
+// amplitude : amplitude of the resulting noise
+// angle : angle of the main oscillation pattern
+// frequency : frequency of the oscillations
+// bandwidth : bandwidth of the noise kernels (inverse of the noise radius)
+// normalized : true if all oscillations should use the full range [0, amplitude]. false to allow contrast variations
+// }
+// -------------END------------------
+
+// @PHASOR
+#define M_PI 3.14159265358979323846
+const uint PHASOR_LCG_N = 15487469u;
+uint hash(uint x) {
+    x = ((x >> 16) ^ x) * 0x45d9f3bu;
+    x = ((x >> 16) ^ x) * 0x45d9f3bu;
+    x = ((x >> 16) ^ x);
+    return x;
+}
+void seed(inout uint x_, uint s) { x_ = hash(s) % PHASOR_LCG_N; }
+uint next(inout uint x_) {
+    x_ *= 3039177861u;
+    x_ = x_ % PHASOR_LCG_N;
+    return x_;
+}
+float uni_0_1(inout uint x_) { return float(next(x_)) / float(PHASOR_LCG_N); }
+float uni(inout uint x_, float min, float max) {
+    return min + (uni_0_1(x_) * (max - min));
+}
+
+uint phasor_morton(uint x, uint y) {
+    uint z = 0u;
+    for (uint i = 0u; i < 32u * 4u; i++) {
+        z |= ((x & (1u << i)) << i) | ((y & (1u << i)) << (i + 1u));
+    }
+    return z;
+}
+
+vec3 gaussian(vec2 x, float b) {
+    float a = exp(-M_PI * (b * b) * ((x.x * x.x) + (x.y * x.y)));
+    vec2 d = -2. * M_PI * b * b * x;
+    // Gaussian value, X derivative, Y derivative
+    return a * vec3(1., d.x, d.y);
+}
+
+float phasor(vec2 pos, float amplitude, float angle, float frequency,
+             float bandwidth, bool normalized) {
+    // The cell size is the kernel radius
+    // The kernel radius is sqrt(-log(0.05) / M_PI) / bandwidth
+    const float THRESHOLD = 0.05;
+    float RADIUS = sqrt(-log(THRESHOLD) / M_PI) / bandwidth;
+
+    // Find current index in grid
+    ivec2 cgridCell = ivec2(floor(pos / RADIUS));
+    ivec2 cg;
+
+    // Static configuration
+    const int LOOKAHEAD = 1;
+    const int NKERNELS = 8;
+
+    // Complex accumulator
+    vec2 res = vec2(0.);
+    vec2 w = vec2(cos(angle), sin(angle));
+
+    // Look at neighbor cells for contributions
+    for (cg.x = cgridCell.x - LOOKAHEAD; cg.x <= cgridCell.x + LOOKAHEAD;
+         ++cg.x) {
+        for (cg.y = cgridCell.y - LOOKAHEAD; cg.y <= cgridCell.y + LOOKAHEAD;
+             ++cg.y) {
+            // Seed the rng using a hash of the current cell number
+            uint rngState;
+            seed(rngState, hash(333u + phasor_morton(uint(cg.x), uint(cg.y))));
+
+            // Now generate impulses
+            for (int k = 0; k < NKERNELS; ++k) {
+                // Impulse center in world coordinates
+                vec2 impulseCenter =
+                    RADIUS *
+                    (vec2(cg) + vec2(uni_0_1(rngState), uni_0_1(rngState)));
+                // Vector from current pos to impulse center
+                vec2 d = pos - impulseCenter;
+                // Gaussian parameter
+                float g = gaussian(d, bandwidth).x;
+                // No contribution from kernels < 5% intensity
+                if (g > THRESHOLD) {
+                    // Scale gaussian contribution to avoid discontinuity
+                    g = (g - THRESHOLD) * (1. + THRESHOLD);
+
+                    // Contribute oscillating part
+                    float ph = 2. * M_PI * frequency * dot(d, w);
+                    res += g * vec2(cos(ph), sin(ph));
+                }
+            }
+        }
+    }
+
+    res /= sqrt(NKERNELS);
+
+    // Compute phasor noise at the right amplitude
+    return amplitude * (normalized ? 1.0 : length(res)) *
+           (.5 + .5 * sin(atan(res.y, res.x)));
+}
+// @END


### PR DESCRIPTION
This PR adds a *Phasor noise* feature based on [Procedural Phasor Noise](https://hal.inria.fr/hal-02118508). Typical use in a terrain map would be as follows:

```glsl
  terrain = phasor(pos, 600.0, 0.0, 0.001, 0.001, false);
```